### PR TITLE
control-structure.rst 번역 일부 옮김

### DIFF
--- a/control-structures.rst
+++ b/control-structures.rst
@@ -96,8 +96,7 @@ Function Calls
 Internal Function Calls
 -----------------------
 
-Functions of the current contract can be called directly ("internally"), also recursively, as seen in
-this nonsensical example::
+예제에서 처럼 현재 contract의 함수는 직접적으로(내부적으로) 또는 재귀적으로 호출 될 수 있다.::
 
     pragma solidity >=0.4.16 <0.6.0;
 
@@ -106,10 +105,7 @@ this nonsensical example::
         function f() internal pure returns (uint ret) { return g(7) + f(); }
     }
 
-These function calls are translated into simple jumps inside the EVM. This has
-the effect that the current memory is not cleared, i.e. passing memory references
-to internally-called functions is very efficient. Only functions of the same
-contract can be called internally.
+이런 함수 calls은 EVM 내부의 간단한 jumps로 번역 될 수 있다. 이것은 현재 돈이 정리되지 않았을 때 내부적으로 호출된 함수에 대한 메모리 참조 변환이 매우 효과적이다. 같은 contract 함수에 대해서만 내부적으로 호출 될 수 있다.
 
 You should still avoid excessive recursion, as every internal function call
 uses up at least one stack slot and there are at most 1024 slots available.
@@ -117,21 +113,15 @@ uses up at least one stack slot and there are at most 1024 slots available.
 External Function Calls
 -----------------------
 
-The expressions ``this.g(8);`` and ``c.g(2);`` (where ``c`` is a contract
-instance) are also valid function calls, but this time, the function
-will be called "externally", via a message call and not directly via jumps.
-Please note that function calls on ``this`` cannot be used in the constructor, as the
-actual contract has not been created yet.
+표현식 ``this.g(8);`` 와 ``c.g(2);`` (g는 contract 인스턴스이다)은 유효한 함수 calls이다. 그러나 함수는 jumps가 아닌 메시지 call을 통해 외부에서 불려진다. 실제 contrat가 아직 생성되지 않았기 때문에 생성자에서 함수 calls은 사용 될 수 없다.
 
-Functions of other contracts have to be called externally. For an external call,
-all function arguments have to be copied to memory.
+다른 contracts의 함수는 외부적으로 호출되어야 한다. 외부 호출을 위해 모든 함수 arguments는 메모리에 복사되어야 한다.
 
 .. note::
     A function call from one contract to another does not create its own transaction,
     it is a message call as part of the overall transaction.
 
-When calling functions of other contracts, the amount of Wei sent with the call and
-the gas can be specified with special options ``.value()`` and ``.gas()``, respectively::
+다른 contracts의 함수를 부를 때, call과 함께 보내진 Wei와 gas는 각각 ``.value()`` 와 ``.gas()`` 로 명시될 수 있다.::
 
     pragma solidity >=0.4.0 <0.6.0;
 
@@ -151,9 +141,7 @@ otherwise, the ``.value()`` option would not be available.
 .. warning::
   Be careful that ``feed.info.value(10).gas(800)`` only locally sets the ``value`` and amount of ``gas`` sent with the function call, and the parentheses at the end perform the actual call. So in this case, the function is not called.
 
-Function calls cause exceptions if the called contract does not exist (in the
-sense that the account does not contain code) or if the called contract itself
-throws an exception or goes out of gas.
+함수 calls은 호출된 contract가 존재하지 않거나(계좌가 코드를 포함하지 않는 다는 점에서), 호출된 contract가 스스로 예외처리를 하거나 gas가 없으면 예외를 발생시킨다.
 
 .. warning::
     Any interaction with another contract imposes a potential danger, especially
@@ -173,10 +161,7 @@ throws an exception or goes out of gas.
 Named Calls and Anonymous Function Parameters
 ---------------------------------------------
 
-Function call arguments can be given by name, in any order,
-if they are enclosed in ``{ }`` as can be seen in the following
-example. The argument list has to coincide by name with the list of
-parameters from the function declaration, but can be in arbitrary order.
+다음의 예에서 볼 수 있는 것처럼 ``{`` ``}`` 로 묶여 있다면, 함수 호출 arguments는 순서와 상관없이 이름으로 지정 될 수 있다. argument list는 함수 선언에서 parameters 리스트와 이름이 일치해야 하지만 순서는 일치 되지 않을 수 있다.
 
 ::
 
@@ -198,8 +183,7 @@ parameters from the function declaration, but can be in arbitrary order.
 Omitted Function Parameter Names
 --------------------------------
 
-The names of unused parameters (especially return parameters) can be omitted.
-Those parameters will still be present on the stack, but they are inaccessible.
+사용되지 않을 parameters(특히 반환 parameters)의 이름은 제거될 수 있다. 이런 parameters의 이름은 스택에 존재하지만 접근할 수 없다.
 
 ::
 


### PR DESCRIPTION
* [#27](https://github.com/solidity-korea/solidity-docs-kr/issues/27)에 대한 작업 중 일부인, **[ggs134님의 레포](https://ggs134.gitbooks.io/solidityguide/content/)에서 번역된 부분(4.5.2 Function Calls) 일부**를 옮겼습니다.
  * [ggs134님의 레포](https://ggs134.gitbooks.io/solidityguide/content/)와 [Solidity-docs](https://solidity-kr.readthedocs.io/ko/latest/index.html) 와 일부 다른 내용이 있어, 보다 자세히 읽어보며 이해하기에 더 좋은 문장으로 번역하겠습니다.


* 남은 작업
  * [ggs134님의 레포](https://ggs134.gitbooks.io/solidityguide/content/)에서 번역된 부분(4.5.2 Function Calls) 나머지 옮기기
  * Control Structures, Creating Contracts via new 번역


* 늦어져서 죄송합니다. 빠른 시일 내에 나머지 작업 또한 완료하겠습니다.